### PR TITLE
logic issue in TapDelay::setTapDelays() 

### DIFF
--- a/src/TapDelay.cpp
+++ b/src/TapDelay.cpp
@@ -67,11 +67,6 @@ void TapDelay :: setTapDelays( std::vector<unsigned long> taps )
       oStream_ << "TapDelay::setTapDelay: argument (" << taps[i] << ") greater than maximum!\n";
       handleError( StkError::WARNING ); return;
     }
-
-    if ( taps[i] < 0 ) {
-      oStream_ << "TapDelay::setDelay: argument (" << taps[i] << ") less than zero!\n";
-      handleError( StkError::WARNING ); return;
-    }
   }
 
   if ( taps.size() != outPoint_.size() ) {


### PR DESCRIPTION
The `setTapDelays()` method in `TapDelay` takes in a vector of **unsigned longs**:
`void TapDelay :: setTapDelays( std::vector<unsigned long> taps )`

[On line 71](https://github.com/thestk/stk/blob/master/src/TapDelay.cpp#L71), we have this if-statement:
`if ( taps[i] < 0 ) {`

but isn't this always false if the `taps` array only has _unsigned_ longs? 
