### PR TITLE
make casts in Fir.h explicit

### DIFF
--- a/include/Fir.h
+++ b/include/Fir.h
@@ -88,7 +88,7 @@ inline StkFloat Fir :: tick( StkFloat input )
   lastFrame_[0] = 0.0;
   inputs_[0] = gain_ * input;
 
-  for ( unsigned int i=b_.size()-1; i>0; i-- ) {
+  for ( unsigned int i=(unsigned int)(b_.size())-1; i>0; i-- ) {
     lastFrame_[0] += b_[i] * inputs_[i];
     inputs_[i] = inputs_[i-1];
   }
@@ -112,7 +112,7 @@ inline StkFrames& Fir :: tick( StkFrames& frames, unsigned int channel )
     inputs_[0] = gain_ * *samples;
     *samples = 0.0;
 
-    for ( i=b_.size()-1; i>0; i-- ) {
+    for ( i=(unsigned int)b_.size()-1; i>0; i-- ) {
       *samples += b_[i] * inputs_[i];
       inputs_[i] = inputs_[i-1];
     }
@@ -139,7 +139,7 @@ inline StkFrames& Fir :: tick( StkFrames& iFrames, StkFrames& oFrames, unsigned 
     inputs_[0] = gain_ * *iSamples;
     *oSamples = 0.0;
 
-    for ( i=b_.size()-1; i>0; i-- ) {
+    for ( i=(unsigned int)b_.size()-1; i>0; i-- ) {
       *oSamples += b_[i] * inputs_[i];
       inputs_[i] = inputs_[i-1];
     }


### PR DESCRIPTION
Silences LLVM compiler warnings about losing integer precision. 
