### PR TITLE
Add configure options to build static or shared libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,26 @@ else
 fi
 AC_MSG_RESULT($realtime)
 
+AC_MSG_CHECKING(whether to build the static library)
+AC_ARG_ENABLE(static,
+         [  --disable-static = do not compile static library ],
+	 build_static=$enableval,
+	 build_static=yes)
+AC_SUBST(build_static)
+AC_MSG_RESULT($build_static)
+
+AC_MSG_CHECKING(whether to build the shared library)
+AC_ARG_ENABLE(shared,
+         [  --enable-shared = compile the shared library ],
+	 build_shared=$enableval,
+	 build_shared=no)
+AC_SUBST(build_shared)
+AC_MSG_RESULT($build_shared)
+
+if test x$build_static = xno -a x$build_shared = xno ; then
+        AC_MSG_ERROR([ both static and shared libraries are disabled], 1)
+fi
+
 # Check for math library
 AC_CHECK_LIB(m, cos, , AC_MSG_ERROR(math library is needed!))
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -55,6 +55,16 @@ ifeq ($(REALTIME),yes)
 	OBJECTS += RtMidi.o RtAudio.o RtWvOut.o RtWvIn.o InetWvOut.o InetWvIn.o Thread.o Mutex.o Socket.o TcpClient.o TcpServer.o UdpSocket.o @objects@
 endif
 
+BUILD_STATIC = @build_static@
+BUILD_SHARED = @build_shared@
+DEFAULT_TARGETS = 
+ifeq ($(BUILD_STATIC),yes)
+ DEFAULT_TARGETS += $(STATICLIB)
+endif
+ifeq ($(BUILD_SHARED),yes)
+ DEFAULT_TARGETS += $(SHAREDLIB)
+endif
+
 RAWWAVES = @rawwaves@
 ifeq ($(strip $(RAWWAVES)), )
 	RAWWAVES = ../../rawwaves/
@@ -67,7 +77,7 @@ DEFS    += -DRAWWAVE_PATH=\"$(RAWWAVES)\"
 %.o : ../src/include/%.cpp $(OBJECT_PATH)/.placeholder
 	$(CC) $(CFLAGS) $(DEFS) -c $(<) -o $(OBJECT_PATH)/$@
 
-all : $(STATICLIB)
+all : $(DEFAULT_TARGETS)
 
 $(OBJECT_PATH)/.placeholder:
 	mkdir -vp $(OBJECT_PATH)


### PR DESCRIPTION
Distributors need to build a single stk shared library and other projects use that. This patch adds two configure options: one to disable static linking and one to enable the shared library.

The default is to keep the current behavior of building the static library
