### PR TITLE
Whistle: Replace const declarations with typedefs

### DIFF
--- a/src/Whistle.cpp
+++ b/src/Whistle.cpp
@@ -26,15 +26,12 @@ const int CAN_RADIUS = 100;
 const int PEA_RADIUS = 30;
 const int BUMP_RADIUS = 5;
 
-typedef StkFloat WhistleCanLoss;
-WhistleCanLoss NORM_CAN_LOSS = 0.97;
-WhistleCanLoss SLOW_CAN_LOSS = 0.90;
-
+const StkFloat NORM_CAN_LOSS = 0.97;
+//const StkFloat SLOW_CAN_LOSS = 0.90;
 const StkFloat GRAVITY = 20.0;
 
-typedef StkFloat WhistleTickSize;
-WhistleTickSize NORM_TICK_SIZE = 0.004;
-WhistleTickSize SLOW_TICK_SIZE = 0.0001;
+const StkFloat NORM_TICK_SIZE = 0.004;
+//const StkFloat SLOW_TICK_SIZE = 0.0001;
 
 const StkFloat ENV_RATE = 0.001;
 


### PR DESCRIPTION
From reading the code, it looks like these would be better off wrapped in a `typedef`. 

Added bonus: it gets rid of the compiler warning about `SLOW_CAN_LOSS` and `SLOW_TICK_SIZE` being unused. 
