### PR TITLE
fix Twang.cpp

### DIFF
--- a/src/Twang.cpp
+++ b/src/Twang.cpp
@@ -66,6 +66,7 @@ void Twang :: setFrequency( StkFloat frequency )
   }
 #endif
 
+  frequency_ = frequency;
   // Delay = length - filter delay.
   StkFloat delay = ( Stk::sampleRate() / frequency ) - loopFilter_.phaseDelay( frequency );
   delayLine_.setDelay( delay );


### PR DESCRIPTION
Was producing noise (values far in excess of +/- 1.0) This is with both VC++12 and VC++11, using the eguitar project.
r̶e̶v̶e̶r̶t̶e̶d̶ ̶t̶h̶e̶ ̶l̶i̶n̶e̶ ̶r̶e̶m̶o̶v̶e̶d̶ ̶s̶o̶m̶e̶t̶i̶m̶e̶ ̶s̶i̶n̶c̶e̶ ̶4̶.̶4̶.̶4̶
nope, my mistake, can't find that line anywhere, perhaps I added it myself ages ago and forgot. 
