### PR TITLE
added StkFrames::setChannel

### DIFF
--- a/include/Stk.h
+++ b/include/Stk.h
@@ -381,6 +381,14 @@ public:
   */
   StkFrames& copyChannel(unsigned int channel,StkFrames& destinationFrames, unsigned int destinationChannel) const;
 
+  //! Sets a single channel
+  /*!
+    Copies the \c sourceChannel of \c sourceFrames into the \c channel of self.
+    SourceFrames.frames() must be equal to frames().
+    No range checking is performed unless _STK_DEBUG_ is defined.
+  */
+  void setChannel(unsigned int channel,const StkFrames &sourceFrames,unsigned int sourceChannel);
+
   //! Return the number of channels represented by the data.
   unsigned int channels( void ) const { return nChannels_; };
 

--- a/src/Stk.cpp
+++ b/src/Stk.cpp
@@ -345,6 +345,32 @@ StkFrames& StkFrames::copyChannel(unsigned int sourceChannel,StkFrames& destinat
         
 }
 
+void StkFrames::setChannel(unsigned int destinationChannel, const stk::StkFrames &sourceFrames,unsigned int sourceChannel)
+{
+#if defined(_STK_DEBUG_)
+  if (sourceChannel > sourceFrames.channels() - 1) {
+    std::ostringstream error;
+    error << "StkFrames::setChannel invalid sourceChannel (" << sourceChannel << ")";
+    Stk::handleError( error.str(), StkError::FUNCTION_ARGUMENT);
+  }
+  if (destinationChannel > channels() - 1) {
+    std::ostringstream error;
+    error << "StkFrames::setChannel invalid channel (" << destinationChannel << ")";
+    Stk::handleError( error.str(), StkError::FUNCTION_ARGUMENT );
+  }
+  if (f.frames() != frames()) {
+    std::ostringstream error;
+    error << "StkFrames::setChannel f.frames() != frames();
+    Stk::handleError( error.str(), StkError::MEMORY_ACCESS);
+  }
+#endif
+  unsigned int sourceHop = sourceFrames.nChannels_;
+  unsigned int destinationHop = nChannels_;
+  for (int i  = destinationChannel,j = sourceChannel ; i < nFrames_ * nChannels_; i+=destinationHop,j+=sourceHop) {
+    data_[i] = sourceFrames[j];
+  }
+}
+
 StkFloat StkFrames :: interpolate( StkFloat frame, unsigned int channel ) const
 {
 #if defined(_STK_DEBUG_)


### PR DESCRIPTION
looks like

``` c++
void setChannel(unsigned int channel,const StkFrames &sourceFrames,unsigned int sourceChannel);
```

copies the `sourceChannel` of `sourceFrames` into the specified `channel` of self. Useful for people wanted to to use StkFrames as a mixer interface.
