### PR TITLE
Renamed StkFrames::copyChannel to StkFrames::getChannel

### DIFF
--- a/include/Stk.h
+++ b/include/Stk.h
@@ -373,13 +373,13 @@ public:
   */
   void resize( size_t nFrames, unsigned int nChannels, StkFloat value );
 
-  //! Copies a single channel
+  //! Retrieves a single channel
   /*!
     Copies the specified \c channel into \c destinationFrames's \c destinationChannel. \c destinationChannel must be between 0 and destination.channels() - 1 and
     \c channel must be between 0 and channels() - 1. destination.frames() must be >= frames().
     No range checking is performed unless _STK_DEBUG_ is defined.
   */
-  StkFrames& copyChannel(unsigned int channel,StkFrames& destinationFrames, unsigned int destinationChannel) const;
+  StkFrames& getChannel(unsigned int channel,StkFrames& destinationFrames, unsigned int destinationChannel) const;
 
   //! Return the number of channels represented by the data.
   unsigned int channels( void ) const { return nChannels_; };

--- a/src/Stk.cpp
+++ b/src/Stk.cpp
@@ -317,7 +317,7 @@ void StkFrames :: resize( size_t nFrames, unsigned int nChannels, StkFloat value
   for ( size_t i=0; i<size_; i++ ) data_[i] = value;
 }
     
-StkFrames& StkFrames::copyChannel(unsigned int sourceChannel,StkFrames& destinationFrames, unsigned int destinationChannel) const
+StkFrames& StkFrames::getChannel(unsigned int sourceChannel,StkFrames& destinationFrames, unsigned int destinationChannel) const
 {
 #if defined(_STK_DEBUG_)
   if (sourceChannel > channels() - 1) {


### PR DESCRIPTION
This is a more fitting name. Stupid of me not to think of it before sorry.
