### PR TITLE
Fix install target for new soname scheme

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -91,7 +91,6 @@ $(SHAREDLIB) : $(OBJECTS)
 	$(RM) -f $(@) $(SHAREDLIB).$(MAJOR) $(SHAREDLIB)
 	$(CC) $(LDFLAGS) -fPIC @libflags@ $(OBJECT_PATH)/*.o $(LIBS)
 	$(LN) -s @sharedname@ $(SHAREDLIB)
-#	$(LN) -s @sharedname@ $(SHAREDLIB).$(MAJOR)
 
 install-headers:
 	install -d $(DESTDIR)$(PREFIX)$(INCLUDEDIR)/stk
@@ -99,9 +98,8 @@ install-headers:
 
 install: $(SHAREDLIB) install-headers
 	install -d $(DESTDIR)$(PREFIX)$(LIBDIR)
-	install -m 644 $(SHAREDLIB).$(RELEASE) $(DESTDIR)$(PREFIX)$(LIBDIR)
-	ln -sf $(SHAREDLIB).$(RELEASE) $(DESTDIR)$(PREFIX)$(LIBDIR)/$(SHAREDLIB)
-	ln -sf $(SHAREDLIB).$(RELEASE) $(DESTDIR)$(PREFIX)$(LIBDIR)/$(SHAREDLIB).$(MAJOR)
+	install -m 644 @sharedname@ $(DESTDIR)$(PREFIX)$(LIBDIR)
+	ln -sf @sharedname@ $(DESTDIR)$(PREFIX)$(LIBDIR)/$(SHAREDLIB)
 
 
 $(OBJECTS) : Stk.h


### PR DESCRIPTION
This should have been part of #27, sorry for not noticing before.