### PR TITLE
Fix build on case-sensitive OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ if test $realtime = yes; then
     api="$api -D__MACOSX_CORE__"
     AC_MSG_RESULT(using CoreAudio)
     AC_CHECK_HEADER(CoreAudio/CoreAudio.h, [], [AC_MSG_ERROR(CoreAudio header files not found!)] )
-    LIBS="$LIBS -framework CoreAudio -framework CoreFoundation -framework CoreMidi" ], )
+    LIBS="$LIBS -framework CoreAudio -framework CoreFoundation -framework CoreMIDI" ], )
 
     # If no audio api flags specified, use CoreAudio
     if [test "$api" == ""; ] then
@@ -176,7 +176,7 @@ if test $realtime = yes; then
       AC_CHECK_HEADER(CoreAudio/CoreAudio.h,
       [],
       [AC_MSG_ERROR(CoreAudio header files not found!)] )
-      AC_SUBST( LIBS, ["-framework CoreAudio -framework CoreFoundation -framework CoreMidi"] )
+      AC_SUBST( LIBS, ["-framework CoreAudio -framework CoreFoundation -framework CoreMIDI"] )
     fi
 
     AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(RtAudio requires the pthread library!))

--- a/doc/doxygen/compile.txt
+++ b/doc/doxygen/compile.txt
@@ -56,7 +56,7 @@ STK compiles with realtime support on the following flavors of the Unix operatin
   <TD>Macintosh OS X</TD>
   <TD>CoreAudio</TD>
   <TD>__MACOSX_CORE__</TD>
-  <TD><TT>pthread, CoreAudio, CoreMidi, CoreFoundation</TT></TD>
+  <TD><TT>pthread, CoreAudio, CoreMIDI, CoreFoundation</TT></TD>
 </TR>
 </TABLE>
 </CENTER>

--- a/src/RtMidi.cpp
+++ b/src/RtMidi.cpp
@@ -1010,7 +1010,7 @@ void MidiOutCore :: openVirtualPort( std::string portName )
 void MidiOutCore :: sendMessage( std::vector<unsigned char> *message )
 {
   // We use the MIDISendSysex() function to asynchronously send sysex
-  // messages.  Otherwise, we use a single CoreMidi MIDIPacket.
+  // messages.  Otherwise, we use a single CoreMIDI MIDIPacket.
   unsigned int nBytes = message->size();
   if ( nBytes == 0 ) {
     errorString_ = "MidiOutCore::sendMessage: no data in message argument!";      


### PR DESCRIPTION
Fix capitalization of CoreMIDI framework to fix build on Macs with
case-sensitive filesystems.