### PR TITLE
FMVoices call to Phonemes::formantFrequency() off by one

### DIFF
--- a/src/FMVoices.cpp
+++ b/src/FMVoices.cpp
@@ -98,8 +98,12 @@ void FMVoices :: setFrequency( StkFloat frequency )
     i = currentVowel_ - 64;
     temp2 = 1.1;
   }
-  else if (currentVowel_ <= 128)	{
+  else if (currentVowel_ < 128)	{
     i = currentVowel_ - 96;
+    temp2 = 1.2;
+  }
+  else {
+    i = 31;
     temp2 = 1.2;
   }
 


### PR DESCRIPTION
Hi!

I got `Phonemes::formantFrequency: index is greater than 31!` and it saddened me a bit.
If you give FMVoices a Spectral Tilt argument of 128.0 it will ask for phoneme 32.
