### PR TITLE
#63: add separate index for tokens in parseString

### DIFF
--- a/src/Skini.cpp
+++ b/src/Skini.cpp
@@ -153,10 +153,12 @@ long Skini :: parseString( std::string& line, Message& message )
 
   // Parse the remaining fields (maximum of 2 more).
   int iValue = 0;
+  unsigned int iToken = iValue + 3; //rgh: MIDI extension argument counts are different from regular MIDI
   long dataType = skini_msgs[iSkini].data2;
   while ( dataType != NOPE ) {
 
-    if ( tokens.size() <= (unsigned int) (iValue+3) ) {
+//    if ( tokens.size() <= (unsigned int) (iValue+3) ) { //rgh: test iToken rather than always testing iValue+3
+    if (tokens.size() <= iToken) {
       oStream_ <<  "Skini::parseString: inconsistency between type table and parsed line:\n   " << line;
       handleError( StkError::WARNING );
       return message.type = 0;
@@ -167,11 +169,13 @@ long Skini :: parseString( std::string& line, Message& message )
     case SK_INT:
       message.intValues[iValue] = atoi( tokens[iValue+3].c_str() );
       message.floatValues[iValue] = (StkFloat) message.intValues[iValue];
+      ++iToken; //rgh: increment token index and value index (below)
       break;
 
     case SK_DBL:
       message.floatValues[iValue] = atof( tokens[iValue+3].c_str() );
       message.intValues[iValue] = (long) message.floatValues[iValue];
+	  ++iToken; //rgh: increment token index and value index (below)
       break;
 
     case SK_STR: // Must be the last field.
@@ -181,7 +185,7 @@ long Skini :: parseString( std::string& line, Message& message )
     default: // MIDI extension message
       message.intValues[iValue] = dataType;
       message.floatValues[iValue] = (StkFloat) message.intValues[iValue];
-      iValue--;
+      //iValue--; //rgh: iValue must increment even when iToken does not; resetting iValue only works sometimes
     }
 
     if ( ++iValue == 1 )

--- a/src/Skini.cpp
+++ b/src/Skini.cpp
@@ -158,7 +158,8 @@ long Skini :: parseString( std::string& line, Message& message )
   while ( dataType != NOPE ) {
 
 //    if ( tokens.size() <= (unsigned int) (iValue+3) ) { //rgh: test iToken rather than always testing iValue+3
-    if (tokens.size() <= iToken) {
+//    if (tokens.size() <= iToken) { //rgh: iToken only tests it more tokens are to be consumed (SK_INT, SK_DBL, SK_STR)
+	  if ((tokens.size() <= iToken) && (dataType < 0))  { //Don't fail if remaining iValues come from skini_msgs[] rather than tokens[].
       oStream_ <<  "Skini::parseString: inconsistency between type table and parsed line:\n   " << line;
       handleError( StkError::WARNING );
       return message.type = 0;

--- a/src/Skini.cpp
+++ b/src/Skini.cpp
@@ -167,19 +167,19 @@ long Skini :: parseString( std::string& line, Message& message )
     switch ( dataType ) {
 
     case SK_INT:
-      message.intValues[iValue] = atoi( tokens[iValue+3].c_str() );
+      message.intValues[iValue] = atoi( tokens[iToken].c_str() ); //rgh: use new index
       message.floatValues[iValue] = (StkFloat) message.intValues[iValue];
       ++iToken; //rgh: increment token index and value index (below)
       break;
 
     case SK_DBL:
-      message.floatValues[iValue] = atof( tokens[iValue+3].c_str() );
+      message.floatValues[iValue] = atof( tokens[iToken].c_str() ); //rgh: use new index
       message.intValues[iValue] = (long) message.floatValues[iValue];
-	  ++iToken; //rgh: increment token index and value index (below)
+      ++iToken; //rgh: increment token index and value index (below)
       break;
 
     case SK_STR: // Must be the last field.
-      message.remainder = tokens[iValue+3];
+      message.remainder = tokens[iToken]; //rgh: use new index
       return message.type;
 
     default: // MIDI extension message


### PR DESCRIPTION
Added a separate index for accessing tokens leaving the original index for values to work as it always does.  Code now correctly parses SKINI text for midi extension commands as well as basic commands.