### PR TITLE
redirect non-conforming writes to cerr to oStream_

### DIFF
--- a/src/Guitar.cpp
+++ b/src/Guitar.cpp
@@ -117,7 +117,7 @@ void Guitar :: setBodyFile( std::string bodyfile )
 void Guitar :: setPluckPosition( StkFloat position, int string )
 {
   if ( position < 0.0 || position > 1.0 ) {
-    std::cerr << "Guitar::setPluckPosition: position parameter out of range!";
+    oStream_ << "Guitar::setPluckPosition: position parameter out of range!";
     handleError( StkError::WARNING ); return;
   }
 
@@ -136,7 +136,7 @@ void Guitar :: setPluckPosition( StkFloat position, int string )
 void Guitar :: setLoopGain( StkFloat gain, int string )
 {
   if ( gain < 0.0 || gain > 1.0 ) {
-    std::cerr << "Guitar::setLoopGain: gain parameter out of range!";
+    oStream_ << "Guitar::setLoopGain: gain parameter out of range!";
     handleError( StkError::WARNING ); return;
   }
 

--- a/src/Mandolin.cpp
+++ b/src/Mandolin.cpp
@@ -75,7 +75,7 @@ void Mandolin :: clear( void )
 void Mandolin :: setPluckPosition( StkFloat position )
 {
   if ( position < 0.0 || position > 1.0 ) {
-    std::cerr << "Mandolin::setPluckPosition: position parameter out of range!";
+    oStream_ << "Mandolin::setPluckPosition: position parameter out of range!";
     handleError( StkError::WARNING ); return;
   }
 

--- a/src/Resonate.cpp
+++ b/src/Resonate.cpp
@@ -56,7 +56,7 @@ void Resonate :: setResonance( StkFloat frequency, StkFloat radius )
   }
 
   if ( radius < 0.0 || radius >= 1.0 ) {
-    std::cerr << "Resonate::setResonance: radius parameter is out of range!";
+    oStream_ << "Resonate::setResonance: radius parameter is out of range!";
     handleError( StkError::WARNING ); return;
   }
 


### PR DESCRIPTION
Most error messages go to oStream_.  Two in guitar.cpp don't conform.