### PR TITLE
Use cp -R instead of cp -r

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -94,7 +94,7 @@ $(SHAREDLIB) : $(OBJECTS)
 
 install-headers:
 	install -d $(DESTDIR)$(PREFIX)$(INCLUDEDIR)/stk
-	cp -r ../include/*.h $(DESTDIR)$(PREFIX)$(INCLUDEDIR)/stk
+	cp -R ../include/*.h $(DESTDIR)$(PREFIX)$(INCLUDEDIR)/stk
 
 install: $(SHAREDLIB) install-headers
 	install -d $(DESTDIR)$(PREFIX)$(LIBDIR)


### PR DESCRIPTION
This PR changes the Makefile to use `cp -R` instead of `cp -r`. According to the `cp(1)` manpage on macOS, the `-r` option is historic its use is strongly discouraged.