### PR TITLE
Use any LDFLAGS set when running ./configure

### DIFF
--- a/projects/demo/Makefile.in
+++ b/projects/demo/Makefile.in
@@ -35,6 +35,7 @@ DEFS     = @CPPFLAGS@
 DEFS    += @byte_order@
 CFLAGS   = @CXXFLAGS@
 CFLAGS  += -I$(INCLUDE) -I$(INCLUDE)/../src/include
+LDFLAGS  = @LDFLAGS@
 LIBRARY = @LIBS@
 
 REALTIME = @realtime@

--- a/projects/effects/Makefile.in
+++ b/projects/effects/Makefile.in
@@ -24,6 +24,7 @@ DEFS     = @CPPFLAGS@
 DEFS    += @byte_order@
 CFLAGS   = @CXXFLAGS@
 CFLAGS  += -I$(INCLUDE) -I$(INCLUDE)/../src/include
+LDFLAGS  = @LDFLAGS@
 LIBRARY = @LIBS@
 
 REALTIME = @realtime@

--- a/projects/eguitar/Makefile.in
+++ b/projects/eguitar/Makefile.in
@@ -24,6 +24,7 @@ DEFS     = @CPPFLAGS@
 DEFS    += @byte_order@
 CFLAGS   = @CXXFLAGS@
 CFLAGS  += -I$(INCLUDE) -I$(INCLUDE)/../src/include
+LDFLAGS  = @LDFLAGS@
 LIBRARY = @LIBS@
 
 REALTIME = @realtime@

--- a/projects/examples/Makefile.in
+++ b/projects/examples/Makefile.in
@@ -18,6 +18,7 @@ DEFS     = @CPPFLAGS@
 DEFS    += @byte_order@
 CFLAGS   = @CXXFLAGS@
 CFLAGS  += -I$(INCLUDE) -I$(INCLUDE)/../src/include
+LDFLAGS  = @LDFLAGS@
 LIBRARY = @LIBS@
 
 REALTIME = @realtime@

--- a/projects/examples/libMakefile.in
+++ b/projects/examples/libMakefile.in
@@ -14,6 +14,7 @@ DEFS     = @CPPFLAGS@
 DEFS    += @byte_order@
 CFLAGS   = @CXXFLAGS@
 CFLAGS  += -I$(INCLUDE) -Iinclude
+LDFLAGS  = @LDFLAGS@
 LIBRARY = @LIBS@
 
 REALTIME = @realtime@

--- a/projects/ragamatic/Makefile.in
+++ b/projects/ragamatic/Makefile.in
@@ -25,6 +25,7 @@ DEFS     = @CPPFLAGS@
 DEFS    += @byte_order@
 CFLAGS   = @CXXFLAGS@
 CFLAGS  += -I$(INCLUDE) -I$(INCLUDE)/../src/include
+LDFLAGS  = @LDFLAGS@
 LIBRARY = @LIBS@
 
 REALTIME = @realtime@

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -48,6 +48,7 @@ DEFS     = @CPPFLAGS@
 DEFS    += @byte_order@
 CFLAGS   = @CXXFLAGS@
 CFLAGS  += $(INCLUDE) -Iinclude -fPIC
+LDFLAGS  = @LDFLAGS@
 LIBS     = @LIBS@
 
 REALTIME = @realtime@


### PR DESCRIPTION
Hi, I'm the maintainer of [stk in MacPorts](https://ports.macports.org/port/stk). I know the long-term goal may be to replace the stk build system with something new, possibly based on cmake, but until then I'd like to contribute some small incremental improvements to the existing build system, some of which I've already been using in MacPorts.

This first change lets the build system honor any LDFLAGS the user set when running ./configure. For example, this now works:

```
$ LDFLAGS=-Wl,-headerpad_max_install_names ./configure --enable-shared
$ make
```