### PR TITLE
Support exec_prefix, bindir, includedir, libdir

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -10,9 +10,11 @@ AR = ar -rsc
 RM = /bin/rm
 LN = /bin/ln
 OBJECT_PATH = @object_path@
-LIBDIR = @libdir@
-PREFIX = @prefix@
-INCLUDEDIR = @includedir@
+prefix = @prefix@
+exec_prefix = @exec_prefix@
+bindir = @bindir@
+libdir = @libdir@
+includedir = @includedir@
 vpath %.o $(OBJECT_PATH)
 
 OBJECTS	=	Stk.o Generator.o Noise.o Blit.o BlitSaw.o BlitSquare.o Granulate.o \
@@ -93,13 +95,13 @@ $(SHAREDLIB) : $(OBJECTS)
 	$(LN) -s @sharedname@ $(SHAREDLIB)
 
 install-headers:
-	install -d $(DESTDIR)$(PREFIX)$(INCLUDEDIR)/stk
-	cp -R ../include/*.h $(DESTDIR)$(PREFIX)$(INCLUDEDIR)/stk
+	install -d $(DESTDIR)$(includedir)/stk
+	cp -R ../include/*.h $(DESTDIR)$(includedir)/stk
 
 install: $(SHAREDLIB) install-headers
-	install -d $(DESTDIR)$(PREFIX)$(LIBDIR)
-	install -m 644 @sharedname@ $(DESTDIR)$(PREFIX)$(LIBDIR)
-	ln -sf @sharedname@ $(DESTDIR)$(PREFIX)$(LIBDIR)/$(SHAREDLIB)
+	install -d $(DESTDIR)$(libdir)
+	install -m 644 @sharedname@ $(DESTDIR)$(libdir)
+	ln -sf @sharedname@ $(DESTDIR)$(libdir)/$(SHAREDLIB)
 
 
 $(OBJECTS) : Stk.h


### PR DESCRIPTION
Autoconf configure scripts allow the user to specify alternate directories for exec_prefix, bindir, includedir, and libdir (see ./configure --help). Now, they are honored by the Makefile.

For example, here's how --libdir was mishandled by the build system before:

```
$ autoreconf
$ make clean
$ rm -rf destroot
$ ./configure --enable-shared --libdir=/usr/local/other
$ make install -j8 DESTDIR=$(PWD)/destroot
$ find destroot -name '*lib*'
destroot/usr/local/usr/local/other/libstk-4.6.1.dylib
destroot/usr/local/usr/local/other/libstk.dylib
```

Here's how it works after my change:

```
$ autoreconf
$ make clean
$ rm -rf destroot
$ ./configure --enable-shared --libdir=/usr/local/other
$ make install -j8 DESTDIR=$(PWD)/destroot
$ find destroot -name '*lib*'
destroot/usr/local/other/libstk-4.6.1.dylib
destroot/usr/local/other/libstk.dylib
```
