### PR TITLE
Set the install_name for the macOS dylib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,7 @@ case $host in
   *-apple*)
   AC_SUBST( sharedlib, ["libstk.dylib"] )
   AC_SUBST( sharedname, ["${basesharedname}.dylib"] )
-  AC_SUBST( libflags, ["-dynamiclib -o ${basesharedname}.dylib"] )
+  AC_SUBST( libflags, ["-dynamiclib -install_name \$(libdir)/${basesharedname}.dylib -o ${basesharedname}.dylib"] )
 esac
 
 if test $realtime = yes; then


### PR DESCRIPTION
Just like on Linux where one sets a shared library's soname, one should set a macOS dylib's install_name, but unlike on Linux, on macOS the install_name should be the absolute path where the library will be installed.

Fixes #40

## Before:

```
$ autoreconf
$ make clean
$ ./configure --prefix=/opt/stk --enable-shared
$ make -j8
$ otool -L src/libstk-4.6.1.dylib | head -n 2
src/libstk-4.6.1.dylib:
	libstk-4.6.1.dylib (compatibility version 0.0.0, current version 0.0.0)
```

## After:

```
$ autoreconf
$ make clean
$ ./configure --prefix=/opt/stk --enable-shared
$ make -j8
$ otool -L src/libstk-4.6.1.dylib | head -n 2
src/libstk-4.6.1.dylib:
	/opt/stk/lib/libstk-4.6.1.dylib (compatibility version 0.0.0, current version 0.0.0)
```