### PR TITLE
Make StkError inherit from std::exception

### DIFF
--- a/include/Stk.h
+++ b/include/Stk.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <stdexcept>
 //#include <cstdlib>
 
 /*! \namespace stk
@@ -82,7 +83,7 @@ typedef double StkFloat;
   be sub-classes to take care of more specific error conditions ... or
   not.
 */
-class StkError
+class StkError : public std::exception
 {
 public:
   enum Type {
@@ -110,7 +111,7 @@ protected:
 public:
   //! The constructor.
   StkError(const std::string& message, Type type = StkError::UNSPECIFIED)
-    : message_(message), type_(type) {}
+    : std::exception(), message_(message), type_(type) {}
 
   //! The destructor.
   virtual ~StkError(void) {};
@@ -126,6 +127,8 @@ public:
 
   //! Returns the thrown error message as a C string.
   virtual const char *getMessageCString(void) { return message_.c_str(); }
+
+  virtual const char *what(void) const throw() { return message_.c_str(); }
 };
 
 


### PR DESCRIPTION
This commit changes the `StkError` class so that it inherits from `std::exceptiion` class and implements `what()` method. It does not alter the current functionality of `StkError` class, exceptions of this class may be caught the same way as before. The commit allows for additional error checking by catching `std::exception` objects.

### Rationale:

From C++ FAQ, Q17.12:

> If possible, you should throw instances of classes that derive (ultimately) from the std::exception class. By making your exception class inherit (ultimately) from the standard exception base-class, you are making life easier for your users (they have the option of catching most things via std::exception), plus you are probably providing them with more information (such as the fact that your particular exception might be a refinement of std::runtime_error or whatever).

Currently, `StkError` class does not inherit from `std::exception`, so the user has to specifically catch `StkError` exceptions. Lack of `what()` method does not allow for standard error handling. This commit allows for additional error checking methods, leaving the current way of exception handling unaltered.

Currently, I'm working on Python interface to the STK library. One of the main problems is that exceptions thrown via `StkError` cannot be converted to Python exceptions in a way that allows for proper error handling, All exceptions are converted to standard `RuntimeError` exceptions, without error message. This commit allows for converting STK exceptions into proper Python exceptions with exception info.
