### PR TITLE
Add StkFrames constructor that wraps pointer to existing buffer

### DIFF
--- a/include/Stk.h
+++ b/include/Stk.h
@@ -285,6 +285,9 @@ public:
   //! Overloaded constructor that initializes the frame data to the specified size with \c value.
   StkFrames( const StkFloat& value, unsigned int nFrames, unsigned int nChannels );
 
+  //! Overloaded constructor that wraps the provided pointer to \c data.
+  StkFrames( StkFloat* data, unsigned int nFrames, unsigned int nChannels = 1 );
+
   //! The destructor.
   ~StkFrames();
 
@@ -440,6 +443,7 @@ private:
   unsigned int nChannels_;
   size_t size_;
   size_t bufferSize_;
+  bool ownData_;
 
 };
 


### PR DESCRIPTION
Adds new constructor to `StkFrames` class that takes a pointer to an existing `StkFloat` buffer and wraps it into the `StkFrames` object. This is useful in frameworks that provide a buffer that needs to be filled with samples. Wrapping the buffer pointer in `StkFrames` class allows sending the buffer directly into `Stk` objects, without need for data copying. A single `tick` invocation is needed to fill the buffer instead of calling `tick` for each sample.

For example, the callback function in `crtsine.cpp` may be written as:
```
int tick( void *outputBuffer, void *inputBuffer, unsigned int nBufferFrames,
         double streamTime, RtAudioStreamStatus status, void *dataPointer )
{
  SineWave *sine = (SineWave *) dataPointer;
  register StkFloat *samples = (StkFloat *) outputBuffer;

#if 1 // new version
  StkFrames wrapper(samples, nBufferFrames, 1);
  sine->tick(wrapper);
#else // original version
  for ( unsigned int i=0; i<nBufferFrames; i++ )
    *samples++ = sine->tick();
#endif

  return 0;
}
```

Test code:
```
#include <iostream>
#include "Stk.h"

void main() {
  // data buffer
  StkFloat buffer[10];
  // wrap the buffer in StkFrames structure
  StkFrames* wrapper = new StkFrames(buffer, 10);
  // write to the wrapper
  (*wrapper)[0] = 1.1;
  std::cout << buffer[0] << " " << (*wrapper)[0] << std::endl;
  // write to the original buffer
  buffer[1] = 2.2;
  std::cout << buffer[1] << " " << (*wrapper)[1] << std::endl;
  // delete the wrapper
  delete wrapper;
  // verify the buffer
  std::cout << buffer[0] << " " << buffer[1] << std::endl;
}
```

Result:
```
1.1 1.1
2.2 2.2
1.1 2.2
```