### PR TITLE
Add missing TapDelay to src/Makefile

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -21,7 +21,7 @@ OBJECTS	=	Stk.o Generator.o Noise.o Blit.o BlitSaw.o BlitSquare.o Granulate.o \
 					Envelope.o ADSR.o Asymp.o Modulate.o SineWave.o FileLoop.o SingWave.o \
 					FileRead.o FileWrite.o WvIn.o FileWvIn.o WvOut.o FileWvOut.o \
 					Filter.o Fir.o Iir.o OneZero.o OnePole.o PoleZero.o TwoZero.o TwoPole.o \
-					BiQuad.o FormSwep.o Delay.o DelayL.o DelayA.o \
+					BiQuad.o FormSwep.o Delay.o DelayL.o DelayA.o TapDelay.o\
 					\
 					Effect.o PRCRev.o JCRev.o NRev.o FreeVerb.o \
 					Chorus.o Echo.o PitShift.o LentPitShift.o \

--- a/src/Stk.cpp
+++ b/src/Stk.cpp
@@ -313,7 +313,7 @@ void StkFrames :: resize( size_t nFrames, unsigned int nChannels )
       std::string error = "StkFrames::resize: memory allocation error!";
       Stk::handleError( error, StkError::MEMORY_ALLOCATION );
     }
-    if ( ownData ) {
+    if ( ownData_ ) {
       Stk::handleError( "Pointer to external data was lost after resize", StkError::WARNING );
     }
 #endif


### PR DESCRIPTION
Makefile.in in src dir did not include TapDelay.cpp, so that file was not compiled into the static library when configure/make was used.