### PR TITLE
Allow deriving classes from StkFrames

### DIFF
--- a/include/Stk.h
+++ b/include/Stk.h
@@ -286,13 +286,13 @@ public:
   StkFrames( const StkFloat& value, unsigned int nFrames, unsigned int nChannels );
 
   //! The destructor.
-  ~StkFrames();
+  virtual ~StkFrames();
 
   // A copy constructor.
   StkFrames( const StkFrames& f );
 
   // Assignment operator that returns a reference to self.
-  StkFrames& operator= ( const StkFrames& f );
+  virtual StkFrames& operator= ( const StkFrames& f );
 
   //! Subscript operator that returns a reference to element \c n of self.
   /*!
@@ -384,7 +384,7 @@ public:
     size.  Further, no new memory is allocated when the new size is
     smaller or equal to a previously allocated size.
   */
-  void resize( size_t nFrames, unsigned int nChannels = 1 );
+  virtual void resize( size_t nFrames, unsigned int nChannels = 1 );
 
   //! Resize self to represent the specified number of channels and frames and perform element initialization.
   /*!
@@ -394,7 +394,7 @@ public:
     size.  Further, no new memory is allocated when the new size is
     smaller or equal to a previously allocated size.
   */
-  void resize( size_t nFrames, unsigned int nChannels, StkFloat value );
+  virtual void resize( size_t nFrames, unsigned int nChannels, StkFloat value );
 
   //! Retrieves a single channel
   /*!
@@ -432,7 +432,7 @@ public:
    */
   StkFloat dataRate( void ) const { return dataRate_; };
 
-private:
+protected:
 
   StkFloat *data_;
   StkFloat dataRate_;


### PR DESCRIPTION
This modification allows for creating classes that inherit from `StkFrames`.

In `StkFrames` class, `private` members were changed to `protected`. The following methods were made virtual: `~StkFrames`, `operator=` and `resize` (both versions). These method allocate/free memory for the data pointer, so they have to be virtual.

An example usage is wrapping a pointer to buffer provided in a callback function into a custom class derived from `StkFrames`. Such a class may be passed to STK functions as an argument of `StkFrames`, using polymorphism.

The attached example is `crtsine.cpp` project from STK, reworked using a custom wrapper.

[crtsine.cpp.txt](https://github.com/thestk/stk/files/6190300/crtsine.cpp.txt)
