### PR TITLE
Fix out-of-bounds read in LentPitShift

### DIFF
--- a/include/LentPitShift.h
+++ b/include/LentPitShift.h
@@ -142,7 +142,7 @@ inline void LentPitShift::process()
     dpt[delay_] = dt[delay_] * delay_ / cumDt[delay_];
 
     // Look for a minimum
-    if ( dpt[delay_-1]-dpt[delay_-2] < 0 && dpt[delay_]-dpt[delay_-1] > 0 ) {
+    if ( delay_ > 1 && dpt[delay_-1]-dpt[delay_-2] < 0 && dpt[delay_]-dpt[delay_-1] > 0 ) {
       // Check if the minimum is under the threshold
       if ( dpt[delay_-1] < threshold_ ){
         lastPeriod_ = delay_-1;


### PR DESCRIPTION
This PR fixes an out-of-bounds read in `process` method in `LentPitShift` class.

In this loop:
```
  for ( delay_=1; delay_<=tMax_; delay_++ ) {
```
the following condition is checked:
```
    if ( dpt[delay_-1]-dpt[delay_-2] < 0 && dpt[delay_]-dpt[delay_-1] > 0 ) {
```
For `delay_ == 1`, out-of-bounds read `dpt[-1]` is attempted.

This produces an undefined behaviour. In normal cases, the code works, But if the code is compiled as a library and used in another environment, a crash may occur and it is difficult to debug (took me about an hour to find the cause).

BTW, this operation:
```
    dpt[delay_] = dt[delay_] * delay_ / cumDt[delay_];
```
produces a `NaN` result if `dpt[delay_]` and `cumDt[delay_]` are both zero (which may happen at the beginning of processing). This also produces an undefined behaviour.