### PR TITLE
simple fix to force c++11 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1) ##TODO: which version is better
 
 project(STK VERSION 4.6.1)
+set (CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 


### PR DESCRIPTION
I was unable to build until I explicitly forced c++11 standard, I was running clion and on OSX (so building with XCode 12.4)

here's some typical errors I encountered there was one other similar error on the main library

/Volumes/EXSSD/DEVELOPMENT/MAPLEPOST/stk/./include/RtMidi.h:137:19: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
     RtMidi(RtMidi&& other) noexcept;
                  ^
/Volumes/EXSSD/DEVELOPMENT/MAPLEPOST/stk/./include/RtMidi.h:137:28: error: expected ';' at end of declaration list
     RtMidi(RtMidi&& other) noexcept;
                           ^
                           ;

