### PR TITLE
Add using math definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 if(NOT IS_BIG_ENDIAN)
   add_definitions(-D__LITTLE_ENDIAN__)
 endif()
-
+add_definitions(-D_USE_MATH_DEFINES)
 if(INSTALL_HEADERS)
     file(GLOB STK_HEADERS "include/*.h")
     install(FILES ${STK_HEADERS} DESTINATION include/stk)


### PR DESCRIPTION
In windows (MSVC) there are compiling errors because of undefined PI definitions. Possibly that is it issue only for windows. Maybe is needed only for windows, so definition can be decorated in if(WIN32) [or similar].