### PR TITLE
Fix mixed up control messages

### DIFF
--- a/src/ModalBar.cpp
+++ b/src/ModalBar.cpp
@@ -9,9 +9,9 @@
     Control Change Numbers: 
        - Stick Hardness = 2
        - Stick Position = 4
-       - Vibrato Gain = 8
+       - Vibrato Gain = 1
        - Vibrato Frequency = 11
-       - Direct Stick Mix = 1
+       - Direct Stick Mix = 8
        - Volume = 128
        - Modal Presets = 16
          - Marimba = 0
@@ -173,9 +173,9 @@ void ModalBar :: controlChange( int number, StkFloat value )
   else if (number == __SK_ProphesyRibbon_) // 16
 		this->setPreset((int) value);
   else if (number == __SK_Balance_) // 8
-    vibratoGain_ = normalizedValue * 0.3;
-  else if (number == __SK_ModWheel_) // 1
     directGain_ = normalizedValue;
+  else if (number == __SK_ModWheel_) // 1
+    vibratoGain_ = normalizedValue * 0.3;
   else if (number == __SK_ModFrequency_) // 11
     vibrato_.setFrequency( normalizedValue * 12.0 );
   else if (number == __SK_AfterTouch_Cont_)	// 128


### PR DESCRIPTION
In ModalBar.cpp the control messages for 'Stick direct mix' and 'Vibrato amplitude' have been mixed up. This also concerns some documentation but the description on https://ccrma.stanford.edu/software/stk/classstk_1_1ModalBar.html, which is generated from the source, is correct. The following changes make modalbar control changes correspond to that documentation.

This is obviously disruptive downstream since existing code using 'Vibrato gain' or 'Stick mix' would have had to bee sending the wrong signal, as is the case in lmms. 

Fixes https://github.com/thestk/stk/issues/143